### PR TITLE
Fix eslint unicorn plugin rule error

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -172,7 +172,7 @@ export default tseslint.config(
       'unicorn/filename-case': ['error', { case: 'kebabCase' }],
       'unicorn/new-for-builtins': 'error',
       'unicorn/no-abusive-eslint-disable': 'error',
-      'unicorn/no-array-instanceof': 'error',
+      'unicorn/no-instanceof-builtins': 'error',
       'unicorn/no-console-spaces': 'error',
       'unicorn/no-for-loop': 'error',
       'unicorn/no-hex-escape': 'error',
@@ -181,7 +181,6 @@ export default tseslint.config(
       'unicorn/no-null': 'off', // Sometimes null is needed in Cloudflare Workers
       'unicorn/no-process-exit': 'off', // Sometimes needed
       'unicorn/no-unreadable-array-destructuring': 'error',
-      'unicorn/no-unsafe-regex': 'error',
       'unicorn/no-unused-properties': 'error',
       'unicorn/number-literal-case': 'error',
       'unicorn/prefer-array-find': 'error',
@@ -200,11 +199,11 @@ export default tseslint.config(
       'unicorn/prefer-regexp-test': 'error',
       'unicorn/prefer-set-has': 'error',
       'unicorn/prefer-spread': 'error',
-      'unicorn/prefer-starts-ends-with': 'error',
+      'unicorn/prefer-string-starts-ends-with': 'error',
       'unicorn/prefer-string-slice': 'error',
       'unicorn/prefer-ternary': 'error',
       'unicorn/prefer-top-level-await': 'off', // Not always appropriate
-      'unicorn/prefer-trim-start-end': 'error',
+      'unicorn/prefer-string-trim-start-end': 'error',
       'unicorn/prefer-type-error': 'error',
       'unicorn/prevent-abbreviations': 'off', // Allow common abbreviations
       'unicorn/throw-new-error': 'error',


### PR DESCRIPTION
Update ESLint configuration to fix deprecated `eslint-plugin-unicorn` rules and ensure compatibility.

The initial `unicorn/no-array-instanceof` rule was deprecated and removed. During the fix, other deprecated `unicorn` rules were identified and updated/removed (`no-unsafe-regex`, `prefer-starts-ends-with` renamed to `prefer-string-starts-ends-with`, and `prefer-trim-start-end` renamed to `prefer-string-trim-start-end`) to ensure full compatibility with the latest `eslint-plugin-unicorn`.