### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}


### PR DESCRIPTION
Potential fix for [https://github.com/Jensen95/skralde-kalender/security/code-scanning/4](https://github.com/Jensen95/skralde-kalender/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow does not interact with the repository contents or require write access, we can set `contents: read` as the minimal permission. This ensures that the `GITHUB_TOKEN` has restricted access, reducing the risk of privilege escalation.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs. Alternatively, it can be added to the specific job (`deploy`) if different jobs require different permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
