### PR TITLE
Add checkout to required workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy to Cloudflare Workers (from CI)
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - uses: ./.github/actions/deploy
 
   deploy-manual:
@@ -29,4 +31,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy to Cloudflare Workers (manual)
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - uses: ./.github/actions/deploy


### PR DESCRIPTION
Add `actions/checkout` to deploy workflow jobs that need repository code access.

The `deploy-from-ci` and `deploy-manual` jobs use a custom deploy action (`./.github/actions/deploy`) which requires access to the repository's files (e.g., `package.json`, source code) to install dependencies and execute deployment commands. Without checking out the code, these jobs would fail.